### PR TITLE
fix: conditional chaining in nav-account-card

### DIFF
--- a/docs/BETTER_AUTH_ANALYSIS.md
+++ b/docs/BETTER_AUTH_ANALYSIS.md
@@ -1,0 +1,225 @@
+# Análisis de Better Auth: useSession y Non-null Assertion
+
+## Resumen Ejecutivo
+
+Este documento analiza el comportamiento del hook `useSession()` de Better Auth en la aplicación DESArregui, específicamente los problemas relacionados con el uso de non-null assertion operator (`!`) y las diferencias entre entornos de desarrollo y producción.
+
+## Contexto del Problema
+
+### Pregunta Original
+En el componente `nav-account-card.tsx`, líneas 187-190, se encontró el siguiente código:
+
+```tsx
+<AvatarLabelGroup
+    size="md"
+    src={data?.user.image}                    // ✅ Conditional chaining
+    title={data!.user.name}                   // ❌ Non-null assertion
+    subtitle={data!.user.email}               // ❌ Non-null assertion  
+    status={data!.user.emailVerified ? "online" : "offline"} // ❌ Non-null assertion
+/>
+```
+
+La pregunta fue: **¿No debería ser todo con conditional chaining?**
+
+## Análisis Técnico
+
+### 1. Comportamiento de `useSession()` en Better Auth
+
+Better Auth exporta `useSession` desde `better-auth/react`:
+
+```tsx
+import { createAuthClient } from 'better-auth/react'
+export const { signIn, signUp, signOut, useSession } = createAuthClient({})
+```
+
+#### Estructura del Hook
+```tsx
+const { 
+  data: session,    // Session | null
+  isPending,        // boolean (loading state)
+  error,           // Error object
+  refetch          // Function to refetch
+} = useSession()
+```
+
+#### ¿Cuándo puede `data` ser null?
+
+**SÍ, `data` puede ser null en múltiples escenarios:**
+
+1. **Estado inicial**: `data` siempre empieza como `null` durante la petición HTTP inicial
+2. **Sesión expirada**: Retorna `null` cuando la sesión ha expirado
+3. **Usuario no autenticado**: Retorna `null` cuando no hay sesión activa
+4. **Errores de red**: Puede retornar `null` si falla la petición a `/get-session`
+5. **Bug conocido**: Hay reportes de que `useSession()` no siempre actualiza el estado correctamente (~50% de las veces)
+
+### 2. Análisis del Problema en el Código
+
+#### Uso Inconsistente
+```tsx
+src={data?.user.image}        // ✅ Conditional chaining correcto
+title={data!.user.name}       // ❌ Non-null assertion peligroso
+subtitle={data!.user.email}   // ❌ Non-null assertion peligroso
+status={data!.user.emailVerified ? "online" : "offline"} // ❌ Non-null assertion peligroso
+```
+
+#### ¿Por qué es problemático el `!` operator?
+
+El non-null assertion (`!`) le dice a TypeScript "confía en mí, este valor nunca será null", pero si `data` es `null`, causará un **runtime crash**:
+
+```tsx
+// Si data = null:
+data!.user.name  // 💥 Cannot read property 'user' of null
+```
+
+#### Guard Insuficiente
+
+El código tiene este guard:
+```tsx
+if (isPending) {
+    return null
+}
+```
+
+**Pero `isPending: false` NO garantiza que `data` tenga valor.** Puede ser `{data: null, isPending: false}` en casos como:
+- Sesión expirada
+- Usuario no logueado  
+- Error en la obtención de datos
+
+## ¿Por qué Funciona en Producción?
+
+### Arquitectura de Protección
+
+La aplicación tiene un mecanismo de protección que explica por qué el `!` operator "funciona":
+
+#### Página Principal (`/(dashboard)/page.tsx`)
+```tsx
+const {data, isPending} = useSession()
+
+useEffect(() => {
+    if (!isPending) {
+        if (!data?.user) {
+            router.push('/login')    // 🔒 REDIRECCIÓN AUTOMÁTICA
+        } else {
+            router.push('/soti')
+        }
+    }
+}, [data?.user, isPending, router])
+```
+
+#### Flujo de Protección
+1. Si `data` es `null` → Automáticamente redirige a `/login`
+2. Solo accede a rutas del dashboard si `data?.user` existe
+3. Nunca llega al `NavAccountCard` sin sesión válida
+
+## Diferencias entre Desarrollo y Producción
+
+### El Problema de Hidratación
+
+La diferencia clave entre desarrollo y producción es un **issue conocido de Better Auth** relacionado con hidratación en Next.js.
+
+#### Issue Reportado
+> "useSession runs on server & produces hydration errors · Issue #2462" - Better Auth GitHub
+
+#### En Desarrollo (`next dev --turbopack`)
+1. **SSR/Hydration más agresivo**: Next.js en desarrollo hace hydratación más estricta
+2. **Hot reloading**: Causa re-renders que exponen el estado temporal `data = null`
+3. **React StrictMode**: Ejecuta hooks dos veces, exponiendo race conditions
+4. **Timing diferente**: Los hooks pueden ejecutarse en momentos inconsistentes
+
+```tsx
+// Primera pasada (Server):
+data = null, isPending = false
+
+// Segunda pasada (Client/Hydration):  
+data = {user: {...}}, isPending = false
+
+// ❌ CRASH: data!.user.name falla en la primera pasada
+```
+
+#### En Producción (`next build + next start`)
+1. **Hidratación optimizada**: El bundle productivo maneja mejor los estados intermedios
+2. **Sin hot reloading**: No hay re-renders inesperados
+3. **SSR optimizado**: El servidor y cliente están más sincronizados
+4. **Timing más predecible**: Los hooks se ejecutan de manera más consistente
+
+```tsx
+// Server y Client más sincronizados:
+data = {user: {...}}, isPending = false  // Consistente
+
+// ✅ Funciona: data!.user.name siempre tiene valor
+```
+
+## Soluciones Recomendadas
+
+### Opción 1: Conditional Chaining (Recomendado)
+```tsx
+<AvatarLabelGroup
+    src={data?.user?.image}
+    title={data?.user?.name}
+    subtitle={data?.user?.email}
+    status={data?.user?.emailVerified ? "online" : "offline"}
+/>
+```
+
+**Ventajas:**
+- Seguro en todos los entornos
+- Maneja todos los casos edge
+- No depende de arquitectura externa
+
+### Opción 2: Guard Explícito
+```tsx
+const {data, isPending} = useSession()
+
+if (isPending) {
+    return <div>Loading...</div>
+}
+
+if (!data?.user) {
+    return <div>Not authenticated</div> // O redirect a login
+}
+
+// Ahora sí puedes asumir que data existe
+return (
+    <AvatarLabelGroup
+        src={data.user.image}           // ✅ Seguro
+        title={data.user.name}          // ✅ Seguro  
+        subtitle={data.user.email}      // ✅ Seguro
+        status={data.user.emailVerified ? "online" : "offline"} // ✅ Seguro
+    />
+)
+```
+
+### Opción 3: Dynamic Import (Para casos extremos)
+```tsx
+import dynamic from 'next/dynamic'
+
+const NavAccountCard = dynamic(() => import('./nav-account-card'), {
+  ssr: false // Deshabilita SSR para evitar hidratación
+})
+```
+
+## Conclusiones
+
+1. **El non-null assertion (`!`) es un antipatrón** en este contexto, aunque "funcione" por la protección del flujo de la aplicación
+
+2. **Es vulnerable a timing issues** especialmente en desarrollo con Better Auth
+
+3. **La diferencia entre desarrollo y producción** se debe a problemas de hidratación documentados en Better Auth
+
+4. **La solución más robusta** es usar conditional chaining (`?.`) que maneja todos los casos de forma segura
+
+5. **Para aplicaciones críticas** como Mesa de Ayuda, la estabilidad debe priorizarse sobre la brevedad del código
+
+## Referencias
+
+- [Better Auth GitHub Issue #2462](https://github.com/better-auth/better-auth/issues/2462) - useSession hydration errors
+- [Next.js Hydration Documentation](https://nextjs.org/docs/messages/react-hydration-error)
+- [Better Auth vs NextAuth Comparison](https://betterstack.com/community/guides/scaling-nodejs/better-auth-vs-nextauth-authjs-vs-autho/)
+
+## Archivo Afectado
+
+`src/components/application/app-navigation/base-components/nav-account-card.tsx:187-190`
+
+---
+
+*Documentación generada para el proyecto DESArregui - Mesa de Ayuda Hub*

--- a/src/components/application/app-navigation/base-components/nav-account-card.tsx
+++ b/src/components/application/app-navigation/base-components/nav-account-card.tsx
@@ -185,9 +185,9 @@ export const NavAccountCard = ({
             <AvatarLabelGroup
                 size="md"
                 src={data?.user.image}
-                title={data!.user.name}
-                subtitle={data!.user.email}
-                status={data!.user.emailVerified ? "online" : "offline"}
+                title={data?.user.name}
+                subtitle={data?.user.email}
+                status={data?.user?.emailVerified ? "online" : "offline"}
             />
 
             <div className="absolute top-1.5 right-1.5">


### PR DESCRIPTION
- Replace non-null assertion operators (!) with safe conditional chaining (?.)
- Ensure consistent null-safe access to user.name, user.email, and user.emailVerified
- Prevents potential runtime crashes during Better Auth session hydration
- Addresses development/production environment differences in useSession hook

This fix resolves the comment: https://github.com/PatricioPastor/DESArregui/commit/2306a6252c29e0db87c4213672972123eb712f2a#r165990001 and add a .md doc with it's corresponding analysis.